### PR TITLE
Build a badge-rich, data-driven GitHub profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<div align="center">
-
 # Brandon Nozaki Miller
 
 ### RIAEvangelist
@@ -8,19 +6,17 @@
 
 **[LinkedIn](https://www.linkedin.com/in/turtlesallthewaydown/) · [YouTube](https://www.youtube.com/brandonnozakimiller) · [Facebook](https://www.facebook.com/RIAEvangelist) · [Open-source work](https://github.com/RIAEvangelist?tab=repositories)**
 
-*Building useful technology and stronger communities—with clarity, compassion, and a little less noise.*
-
-</div>
+*Building useful technology and stronger communities, with clarity, compassion, and a little less noise.*
 
 ## Current focus
 
 ### Veterans & mental health
 
-As a USAF veteran and mental health advocate, I am working to make support more human, accessible, and stigma-free. The focus is on practical tools, community, and honest conversations that respect lived experience—especially for veterans navigating transition, isolation, and mental-health challenges.
+As a USAF veteran and mental health advocate, I am working to make support more human, accessible, and stigma-free. The focus is on practical tools, community, and honest conversations that respect lived experience, especially for veterans navigating transition, isolation, and mental-health challenges.
 
 ### Entrepreneurship & Zen
 
-I explore entrepreneurship as a practice: create useful things, learn in public, serve people well, and build systems that can last. Zen shapes how I approach that work—attention over noise, simplicity over ceremony, and steady progress without attachment to hype.
+I explore entrepreneurship as a practice: create useful things, learn in public, serve people well, and build systems that can last. Zen shapes how I approach that work: attention over noise, simplicity over ceremony, and steady progress without attachment to hype.
 
 ### Technology & open source
 
@@ -34,8 +30,6 @@ I build with traditional JavaScript, Node.js, AI-assisted workflows, and open-so
 
 ## JavaScript vs Python
 
-<a href="https://artists.landr.com/055855493170">
-  <img src="https://raw.githubusercontent.com/RIAEvangelist/RIAEvangelist/main/EP-Cover-transformed.jpg" alt="JavaScript vs Python cover art" width="320">
-</a>
+[![JavaScript vs Python cover art](EP-Cover-transformed.jpg)](https://artists.landr.com/055855493170)
 
 My **JavaScript vs Python** song is available on your favorite music streaming platforms. [Listen here.](https://artists.landr.com/055855493170)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ I build with traditional JavaScript, Node.js, AI-assisted workflows, and open-so
 
 ## Live GitHub dashboard
 
-[![Profile details](https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=RIAEvangelist&theme=radical&animation=load)](https://github.com/RIAEvangelist)
+[![Profile details](https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=RIAEvangelist&theme=radical)](https://github.com/RIAEvangelist)
 
 [![GitHub stats](https://github-profile-summary-cards.vercel.app/api/cards/stats?username=RIAEvangelist&theme=radical&animation=load)](https://github.com/RIAEvangelist?tab=repositories)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,44 @@
-![](https://komarev.com/ghpvc/?username=RIAEvangelist&style=for-the-badge&color=ff69b4) [![Brandon Nozaki Miller Facebook](https://img.shields.io/badge/Facebook-1877F2?style=for-the-badge&logo=facebook&logoColor=white)](https://www.facebook.com/RIAEvangelist) [![Brandon Nozaki Miller LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/turtlesallthewaydown/) [![Brandon Nozaki Miller YouTube](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/brandonnozakimiller) 
+<div align="center">
 
-<a href='https://artists.landr.com/055855493170'>
-<p>JavaScript Vs Python song is out!</p>
-<p>Check it out on your favorite music streaming platforms.</p>
-<img src="https://github.com/RIAEvangelist/RIAEvangelist/blob/main/EP-Cover-transformed.jpg" alt="Javascript vs Python Cover Art" width="250" height="250"></a>
+# Brandon Nozaki Miller
 
+### RIAEvangelist
 
-[![trophy](https://github-profile-trophy.vercel.app/?username=riaevangelist&theme=onedark&column=5)](https://github.com/ryo-ma/github-profile-trophy)
+**USAF Veteran · Traditional JavaScript Engineer · AI Whisperer · Creator · Mental Health Advocate**
 
-![RIAEvangelist, Brandon Nozaki Miller GitHub Stats Card](https://github-readme-stats.vercel.app/api?username=riaevangelist&show_icons=true&theme=radical)
+[![Profile views](https://komarev.com/ghpvc/?username=RIAEvangelist&style=for-the-badge&color=ff69b4)](https://github.com/RIAEvangelist)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/turtlesallthewaydown/)
+[![YouTube](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/brandonnozakimiller)
+[![Facebook](https://img.shields.io/badge/Facebook-1877F2?style=for-the-badge&logo=facebook&logoColor=white)](https://www.facebook.com/RIAEvangelist)
 
-[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=riaevangelist&layout=compact&theme=radical)](https://github.com/anuraghazra/github-readme-stats)
+*Building useful technology and stronger communities—with clarity, compassion, and a little less noise.*
+
+</div>
+
+## Current focus
+
+### Veterans & mental health
+
+As a USAF veteran and mental health advocate, I am working to make support more human, accessible, and stigma-free. The focus is on practical tools, community, and honest conversations that respect lived experience—especially for veterans navigating transition, isolation, and mental-health challenges.
+
+### Entrepreneurship & Zen
+
+I explore entrepreneurship as a practice: create useful things, learn in public, serve people well, and build systems that can last. Zen shapes how I approach that work—attention over noise, simplicity over ceremony, and steady progress without attachment to hype.
+
+### Technology & open source
+
+I build with traditional JavaScript, Node.js, AI-assisted workflows, and open-source tools. I am especially interested in technology that gives people more agency, makes complex systems understandable, and turns ambitious ideas into practical outcomes.
+
+## Follow the work
+
+- [Watch on YouTube](https://www.youtube.com/brandonnozakimiller) for technology, AI, entrepreneurship, mental health, and the human side of building.
+- [Connect on LinkedIn](https://www.linkedin.com/in/turtlesallthewaydown/) for professional updates and collaboration.
+- [Explore my repositories](https://github.com/RIAEvangelist?tab=repositories) for open-source projects and experiments.
+
+## JavaScript vs Python
+
+<a href="https://artists.landr.com/055855493170">
+  <img src="https://raw.githubusercontent.com/RIAEvangelist/RIAEvangelist/main/EP-Cover-transformed.jpg" alt="JavaScript vs Python cover art" width="320">
+</a>
+
+My **JavaScript vs Python** song is available on your favorite music streaming platforms. [Listen here.](https://artists.landr.com/055855493170)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 **USAF Veteran · Traditional JavaScript Engineer · AI Whisperer · Creator · Mental Health Advocate**
 
-**[LinkedIn](https://www.linkedin.com/in/turtlesallthewaydown/) · [YouTube](https://www.youtube.com/brandonnozakimiller) · [Facebook](https://www.facebook.com/RIAEvangelist) · [Open-source work](https://github.com/RIAEvangelist?tab=repositories)**
+[![Profile views](https://komarev.com/ghpvc/?username=RIAEvangelist&style=for-the-badge&color=ff69b4)](https://github.com/RIAEvangelist) [![Facebook](https://img.shields.io/badge/Facebook-1877F2?style=for-the-badge&logo=facebook&logoColor=white)](https://www.facebook.com/RIAEvangelist) [![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/turtlesallthewaydown/) [![YouTube](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/brandonnozakimiller)
+
+[![GitHub followers](https://img.shields.io/github/followers/RIAEvangelist?style=for-the-badge&logo=github&label=Followers&color=ff69b4)](https://github.com/RIAEvangelist?tab=followers) [![Total stars](https://img.shields.io/github/stars/RIAEvangelist?style=for-the-badge&logo=github&label=Total%20Stars&color=7c3aed)](https://github.com/RIAEvangelist?tab=repositories) [![Sponsor](https://img.shields.io/badge/Sponsor-RIAEvangelist-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/RIAEvangelist)
 
 *Building useful technology and stronger communities, with clarity, compassion, and a little less noise.*
 
@@ -12,15 +14,33 @@
 
 ### Veterans & mental health
 
+![USAF Veteran](https://img.shields.io/badge/USAF-Veteran-00308F?style=for-the-badge&logo=unitedstatesairforce&logoColor=white) ![Mental Health Advocate](https://img.shields.io/badge/Mental%20Health-Advocate-6F42C1?style=for-the-badge)
+
 As a USAF veteran and mental health advocate, I am working to make support more human, accessible, and stigma-free. The focus is on practical tools, community, and honest conversations that respect lived experience, especially for veterans navigating transition, isolation, and mental-health challenges.
 
 ### Entrepreneurship & Zen
+
+![Entrepreneurship](https://img.shields.io/badge/Entrepreneurship-Build%20With%20Purpose-F59E0B?style=for-the-badge) ![Zen](https://img.shields.io/badge/Zen-Clarity%20Over%20Noise-2F4F4F?style=for-the-badge)
 
 I explore entrepreneurship as a practice: create useful things, learn in public, serve people well, and build systems that can last. Zen shapes how I approach that work: attention over noise, simplicity over ceremony, and steady progress without attachment to hype.
 
 ### Technology & open source
 
+![JavaScript](https://img.shields.io/badge/JavaScript-Traditional-F7DF1E?style=for-the-badge&logo=javascript&logoColor=000000) ![Node.js](https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white) ![AI](https://img.shields.io/badge/AI-Human%20Centered-FF69B4?style=for-the-badge) ![Open Source](https://img.shields.io/badge/Open%20Source-3DA639?style=for-the-badge&logo=opensourceinitiative&logoColor=white)
+
 I build with traditional JavaScript, Node.js, AI-assisted workflows, and open-source tools. I am especially interested in technology that gives people more agency, makes complex systems understandable, and turns ambitious ideas into practical outcomes.
+
+## Live GitHub dashboard
+
+[![Profile details](https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=RIAEvangelist&theme=radical&animation=load)](https://github.com/RIAEvangelist)
+
+[![GitHub stats](https://github-profile-summary-cards.vercel.app/api/cards/stats?username=RIAEvangelist&theme=radical&animation=load)](https://github.com/RIAEvangelist?tab=repositories)
+
+[![Repositories by language](https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=RIAEvangelist&theme=radical&animation=load)](https://github.com/RIAEvangelist?tab=repositories)
+
+[![Most committed languages](https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=RIAEvangelist&theme=radical&animation=load)](https://github.com/RIAEvangelist?tab=repositories)
+
+[![Productive time](https://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=RIAEvangelist&theme=radical&utcOffset=-7&animation=load)](https://github.com/RIAEvangelist)
 
 ## Follow the work
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@
 
 **USAF Veteran · Traditional JavaScript Engineer · AI Whisperer · Creator · Mental Health Advocate**
 
-[![Profile views](https://komarev.com/ghpvc/?username=RIAEvangelist&style=for-the-badge&color=ff69b4)](https://github.com/RIAEvangelist)
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/turtlesallthewaydown/)
-[![YouTube](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/brandonnozakimiller)
-[![Facebook](https://img.shields.io/badge/Facebook-1877F2?style=for-the-badge&logo=facebook&logoColor=white)](https://www.facebook.com/RIAEvangelist)
+[![Profile views](https://komarev.com/ghpvc/?username=RIAEvangelist&style=for-the-badge&color=ff69b4)](https://github.com/RIAEvangelist) [![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/turtlesallthewaydown/) [![YouTube](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/brandonnozakimiller) [![Facebook](https://img.shields.io/badge/Facebook-1877F2?style=for-the-badge&logo=facebook&logoColor=white)](https://www.facebook.com/RIAEvangelist)
 
 *Building useful technology and stronger communities—with clarity, compassion, and a little less noise.*
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **USAF Veteran · Traditional JavaScript Engineer · AI Whisperer · Creator · Mental Health Advocate**
 
-[![Profile views](https://komarev.com/ghpvc/?username=RIAEvangelist&style=for-the-badge&color=ff69b4)](https://github.com/RIAEvangelist) [![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/turtlesallthewaydown/) [![YouTube](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/brandonnozakimiller) [![Facebook](https://img.shields.io/badge/Facebook-1877F2?style=for-the-badge&logo=facebook&logoColor=white)](https://www.facebook.com/RIAEvangelist)
+**[LinkedIn](https://www.linkedin.com/in/turtlesallthewaydown/) · [YouTube](https://www.youtube.com/brandonnozakimiller) · [Facebook](https://www.facebook.com/RIAEvangelist) · [Open-source work](https://github.com/RIAEvangelist?tab=repositories)**
 
 *Building useful technology and stronger communities—with clarity, compassion, and a little less noise.*
 


### PR DESCRIPTION
## What changed

- restored the original profile-view, Facebook, LinkedIn, and YouTube badges
- added live followers, total stars, and sponsor badges
- added mission badges for USAF Veteran, Mental Health Advocate, Entrepreneurship, and Zen
- added technology badges for JavaScript, Node.js, AI, and Open Source
- added five live GitHub data cards in the radical theme
- added sections for veterans and mental health, Entrepreneurship and Zen, and technology and open source
- replaced the broken trophy and old stats providers
- kept the README as pure Markdown with no HTML tags and no em dashes

## Live data included

- profile views
- followers
- total stars
- contribution history
- repository and contribution statistics
- repositories by language
- most committed languages
- productive time

## Validation

- inspected the rendered branch in Browser
- verified all 21 visual assets load successfully
- verified 15 badges, 5 live stat cards, and the album cover
- confirmed zero HTML tags and zero em dashes in README.md
- reviewed the final README diff
- ran `git diff --check` with no content errors
