### PR TITLE
Restore 14 earned GitHub trophies and milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
 
 *Building useful technology and stronger communities, with clarity, compassion, and a little less noise.*
 
+## Earned milestones
+
+[![Quickdraw](https://img.shields.io/badge/Quickdraw-Earned-F5C542?style=for-the-badge&logo=github&logoColor=white)](https://github.com/RIAEvangelist?achievement=quickdraw&tab=achievements) [![Arctic Code Vault Contributor](https://img.shields.io/badge/Arctic%20Code%20Vault-Contributor-00B4D8?style=for-the-badge&logo=github&logoColor=white)](https://github.com/RIAEvangelist?achievement=arctic-code-vault-contributor&tab=achievements) [![Starstruck x3](https://img.shields.io/badge/Starstruck-x3-FF69B4?style=for-the-badge&logo=github&logoColor=white)](https://github.com/RIAEvangelist?achievement=starstruck&tab=achievements) [![Pull Shark x2](https://img.shields.io/badge/Pull%20Shark-x2-7C3AED?style=for-the-badge&logo=github&logoColor=white)](https://github.com/RIAEvangelist?achievement=pull-shark&tab=achievements)
+
+### GitHub trophy case
+
+[![Earned GitHub trophies](https://trophy.ryglcloud.net/?username=RIAEvangelist&theme=onedark&column=5&margin-w=15&margin-h=15&rank=SECRET,SSS,SS,S,AAA,AA,A,B,C)](https://github.com/ryo-ma/github-profile-trophy)
+
 ## Current focus
 
 ### Veterans & mental health


### PR DESCRIPTION
## What changed

- restored the GitHub trophy case using a working mirror from the trophy project's official load-balancer list
- filtered the trophy board to earned ranks only
- added linked badges for Quickdraw, Arctic Code Vault Contributor, Starstruck x3, and Pull Shark x2
- preserved the existing profile dashboard and focus sections
- kept the README as pure Markdown with no HTML tags and no em dashes

## Verified earned milestones

The trophy case currently renders 10 earned trophies:

- MultiLanguage, rank S
- LongTimeUser, rank S
- AncientUser, rank S
- Repositories, rank S
- Stars, rank S
- Experience, rank S
- Followers, rank S
- Issues, rank A
- PullRequest, rank A
- Commits, rank B

The profile also shows four native GitHub achievements:

- Quickdraw
- Arctic Code Vault Contributor
- Starstruck x3
- Pull Shark x2

## Why

These trophies and native GitHub achievements are meaningful earned milestones and should remain visible on the profile. The original trophy host no longer rendered reliably through GitHub.

## Validation

- confirmed all four native achievements on the live GitHub profile
- verified the replacement trophy endpoint returns a complete earned-only SVG
- verified the branch render contains all 26 visual assets with zero failures
- confirmed the trophy board displays 10 earned trophies and no unknown ranks
- reviewed the README diff
- ran `git diff --check` with no content errors
